### PR TITLE
use proper font name by platform

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -45,7 +45,7 @@ Napi::String StringFromFontString(Napi::Env env, font_info_string *name)
 	delete[] buffer;
 #endif
 #if defined(__APPLE__)
-	name_string = std::string(name->buffer, name->length)
+	name_string = std::string(name->buffer, name->length);
 #endif
 	
 	Napi::String result = Napi::String::New(env, name_string.c_str(), name_string.size());


### PR DESCRIPTION
Issues fixed:
**ASSIGN_STRING** two line macros was executed not as intended after if() statement. 
**FT_Get_Sfnt_Name** have different names for Mac and Win platforms with different encodings. 
**StringFromFontString** used a **buffer** for converting a string but returned original **name->buffer**. 